### PR TITLE
dpkg github releases are not set to the latest release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dpkg
 Title: Create, Stow, and Read Data Packages
-Version: 0.6.0.9000
+Version: 0.6.1
 Authors@R: 
     person("Cole", "Brokamp", , "cole@colebrokamp.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-0289-3151"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# dpkg (development version)
+# dpkg 0.6.1
+
+- dpkg github releases are no longer set to be the "latest" release
 
 # dpkg 0.6.0
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,17 +1,12 @@
 ## R CMD check results
 
-Resubmission of dpkg 0.6.0:
+Submission of dpkg 0.6.1:
 
-- Used only undirected quotation marks in description text
-- Removed example in unexported function
-- Removed commented out examples
-- I believe \dontrun is needed in my case because running the example would error without a user-provided github repository and github API key.
-- I've confirmed that the DESCRIPTION file contains all of the authors, contributors, and copyright holders in the Authors@R section.
+This is a bugfix release.
 
 0 errors | 0 warnings | 0 notes
 
-* This is a new release.
 * R CMD checks passed with above results on:
-  - R v4.4.1 (macos, windows, and ubuntu)
+  - R v4.4.2 (macos, windows, and ubuntu)
   - R v4.3.3 (ubuntu)
   - A development version of R (ubuntu and windows)

--- a/man/dpkg_gh_release.Rd
+++ b/man/dpkg_gh_release.Rd
@@ -4,30 +4,37 @@
 \alias{dpkg_gh_release}
 \title{Use a dpkg to create a github release}
 \usage{
-dpkg_gh_release(x, draft = TRUE, generate_release_notes = FALSE)
+dpkg_gh_release(x, draft = TRUE)
 }
 \arguments{
 \item{x}{a data package (\code{dpkg}) object}
 
 \item{draft}{logical; mark release as draft?}
-
-\item{generate_release_notes}{logical; include GitHub's auto-generated release notes below the description in the release body?}
 }
 \value{
 the URL to the release (invisibly)
 }
 \description{
-The release will be tagged at the current commit and
-named according to the \code{name} and \code{version} of the dpkg.
+A GitHub release will be created based on the current commit,
+tagged and named according to the \code{name} and \code{version} of the dpkg.
+The dpkg \code{description} is used for the release body.
+}
+\details{
 The \code{GITHUB_PAT} environment variable must be set and the working directory
 must be inside of a git repository with a GitHub remote.
-Trying to create more than one release from the current commit will result in an error.
+
+The GitHub release will \emph{not} be set to the latest release in order to prevent
+problems with other automated actions that rely on the latest release, like
+R universe or remotes \code{"*release"} syntax or other GitHub actions.
+
+Release tags are required to be unique, so this will fail if a release with the same
+name and version already exists.
 }
 \examples{
 \dontrun{
 dpkg_gh_release(
   as_dpkg(mtcars,
-    version = "0.0.0.9000", title = "Foofy Cars",
+    version = "0.0.0.9001", title = "Foofy Cars",
     homepage = "https://github.com/cole-brokamp/dpkg",
     description =
       paste("# Foofy Cars\n",
@@ -38,6 +45,6 @@ dpkg_gh_release(
   draft = FALSE
 )
 }
-#> created release at: https://github.com/cole-brokamp/dpkg/releases/tag/mtcars-v0.0.0.9000
+#> created release at: https://github.com/cole-brokamp/dpkg/releases/tag/mtcars-v0.0.0.9001
 
 }


### PR DESCRIPTION
The GitHub release will *not* be set to the latest release in order to prevent problems with other automated actions that rely on the latest release, like R universe or remotes `"*release"` syntax or other GitHub actions.
