### PR TITLE
use digest package instead of rlang for more stable hashes of dpkg objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dpkg
 Title: Create, Stow, and Read Data Packages
-Version: 0.6.1.9000
+Version: 0.6.2
 Authors@R: 
     person("Cole", "Brokamp", , "cole@colebrokamp.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-0289-3151"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dpkg
 Title: Create, Stow, and Read Data Packages
-Version: 0.6.1
+Version: 0.6.1.9000
 Authors@R: 
     person("Cole", "Brokamp", , "cole@colebrokamp.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-0289-3151"))
@@ -11,6 +11,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Suggests: 
     dplyr,
+    digest,
     geoarrow,
     gert,
     gh,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dpkg dev
+
+- use digest package to hash serialized R objects
+
 # dpkg 0.6.1
 
 - dpkg github releases are no longer set to be the "latest" release
@@ -8,4 +12,4 @@
 
 # dpkg 0.5.1
 
-* Initial CRAN submission.
+- Initial CRAN submission.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# dpkg dev
+# dpkg 0.6.2
 
 - use digest package to hash serialized R objects
 

--- a/R/dpkg_release_gh.R
+++ b/R/dpkg_release_gh.R
@@ -11,7 +11,7 @@
 #' The GitHub release will *not* be set to the latest release in order to prevent
 #' problems with other automated actions that rely on the latest release, like
 #' R universe or remotes `"*release"` syntax or other GitHub actions.
-#' 
+#'
 #' Release tags are required to be unique, so this will fail if a release with the same
 #' name and version already exists.
 #' @param x a data package (`dpkg`) object
@@ -36,7 +36,9 @@
 #' #> created release at: https://github.com/cole-brokamp/dpkg/releases/tag/mtcars-v0.0.0.9001
 #'
 dpkg_gh_release <- function(x, draft = TRUE) {
-  if (!inherits(x, "dpkg")) rlang::abort("x must be a `dpkg` object`")
+  if (!inherits(x, "dpkg")) {
+    rlang::abort("x must be a `dpkg` object`")
+  }
   rlang::check_installed("gert", "get current git commit")
   rlang::check_installed("gh", "create a release on github")
   gh_owner <- gh::gh_tree_remote()$username
@@ -56,7 +58,9 @@ dpkg_gh_release <- function(x, draft = TRUE) {
   gh_release_id <- draft_release_details$id
 
   put_asset_req <-
-    glue::glue("https://uploads.github.com/repos/{gh_owner}/{gh_repo}/releases/{gh_release_id}/assets") |>
+    glue::glue(
+      "https://uploads.github.com/repos/{gh_owner}/{gh_repo}/releases/{gh_release_id}/assets"
+    ) |>
     httr2::request() |>
     httr2::req_method("POST") |>
     httr2::req_headers(
@@ -70,11 +74,15 @@ dpkg_gh_release <- function(x, draft = TRUE) {
   written_path <- write_dpkg(x, tempdir())
 
   put_asset_req |>
-    httr2::req_url_query(name = glue::glue("{attr(x, 'name')}-v{attr(x, 'version')}.parquet")) |>
+    httr2::req_url_query(
+      name = glue::glue("{attr(x, 'name')}-v{attr(x, 'version')}.parquet")
+    ) |>
     httr2::req_body_file(written_path) |>
     httr2::req_perform()
 
-  message(glue::glue("created {ifelse(draft, 'draft release', 'release')} at: {draft_release_details$html_url}"))
+  message(glue::glue(
+    "created {ifelse(draft, 'draft release', 'release')} at: {draft_release_details$html_url}"
+  ))
   return(invisible(draft_release_details$html_url))
 }
 
@@ -106,7 +114,9 @@ dpkg_gh_release <- function(x, draft = TRUE) {
 #' }
 #'
 use_dpkg_badge <- function(x) {
-  if (!inherits(x, "dpkg")) rlang::abort("x must be a `dpkg` object`")
+  if (!inherits(x, "dpkg")) {
+    rlang::abort("x must be a `dpkg` object`")
+  }
   rlang::check_installed("gert", "get current git commit")
   rlang::check_installed("gh", "create a release on github")
   gh_owner <- gh::gh_tree_remote()$username
@@ -119,10 +129,15 @@ use_dpkg_badge <- function(x) {
     "&display_name=tag",
     "&label=%5B%E2%98%B0%5D&labelColor=%238CB4C3&color=%23396175"
   )
-  badge_href <- glue::glue("https://github.com/{gh_owner}/{gh_repo}/releases?q={attr(x, 'name')}&expanded=false")
+  badge_href <- glue::glue(
+    "https://github.com/{gh_owner}/{gh_repo}/releases?q={attr(x, 'name')}&expanded=false"
+  )
   rlang::check_installed("usethis", "insert markdown badges into README")
-  usethis::use_badge(glue::glue("latest github release for {attr(x, 'name')} dpkg"),
-                     href = badge_href, src = badge_src)
+  usethis::use_badge(
+    glue::glue("latest github release for {attr(x, 'name')} dpkg"),
+    href = badge_href,
+    src = badge_src
+  )
   return(invisible(glue::glue("[![]({badge_src})](badge_href)")))
 }
 
@@ -132,15 +147,53 @@ get_gh_token <- function() {
   gh_token <- Sys.getenv("GITHUB_PAT")
   if (gh_token == "") {
     message("using bundled github token to access a public repository")
-    message("use your own token by defining the `GITHUB_PAT` environment variable")
+    message(
+      "use your own token by defining the `GITHUB_PAT` environment variable"
+    )
     gh_token <-
       paste0(
         "0x",
         c(
-          "67", "68", "70", "5f", "37", "74", "4d", "50", "65",
-          "32", "6e", "38", "33", "4b", "4c", "75", "47", "57", "44", "32",
-          "6f", "65", "61", "69", "47", "7a", "72", "70", "49", "34", "55",
-          "41", "4d", "58", "33", "44", "48", "78", "33", "47"
+          "67",
+          "68",
+          "70",
+          "5f",
+          "37",
+          "74",
+          "4d",
+          "50",
+          "65",
+          "32",
+          "6e",
+          "38",
+          "33",
+          "4b",
+          "4c",
+          "75",
+          "47",
+          "57",
+          "44",
+          "32",
+          "6f",
+          "65",
+          "61",
+          "69",
+          "47",
+          "7a",
+          "72",
+          "70",
+          "49",
+          "34",
+          "55",
+          "41",
+          "4d",
+          "58",
+          "33",
+          "44",
+          "48",
+          "78",
+          "33",
+          "47"
         )
       ) |>
       as.raw() |>
@@ -161,7 +214,9 @@ stow_gh_release <- function(owner, repo, dpkg, overwrite = FALSE) {
     return(stow_path(dpkg_filename))
   }
   the_release <-
-    httr2::request(glue::glue("https://api.github.com/repos/{owner}/{repo}/releases/tags/{dpkg}")) |>
+    httr2::request(glue::glue(
+      "https://api.github.com/repos/{owner}/{repo}/releases/tags/{dpkg}"
+    )) |>
     httr2::req_headers(
       Accept = "application/vnd.github+json",
       Authorization = glue::glue("Bearer {get_gh_token()}"),
@@ -172,7 +227,9 @@ stow_gh_release <- function(owner, repo, dpkg, overwrite = FALSE) {
     httr2::resp_body_json()
 
   the_assets <-
-    httr2::request(glue::glue("https://api.github.com/repos/{owner}/{repo}/releases/{the_release$id}/assets")) |>
+    httr2::request(glue::glue(
+      "https://api.github.com/repos/{owner}/{repo}/releases/{the_release$id}/assets"
+    )) |>
     httr2::req_headers(
       Accept = "application/vnd.github+json",
       Authorization = glue::glue("Bearer {get_gh_token()}"),
@@ -182,7 +239,11 @@ stow_gh_release <- function(owner, repo, dpkg, overwrite = FALSE) {
     httr2::req_perform() |>
     httr2::resp_body_json()
 
-  the_asset <- the_assets[[which(vapply(the_assets, \(.) .$name == paste0(dpkg, ".parquet"), logical(1)))]]
+  the_asset <- the_assets[[which(vapply(
+    the_assets,
+    \(.) .$name == paste0(dpkg, ".parquet"),
+    logical(1)
+  ))]]
 
   stow_url(the_asset$browser_download_url)
 

--- a/R/dpkg_tibble.R
+++ b/R/dpkg_tibble.R
@@ -23,8 +23,14 @@
 #' attr(x, "description") <- "This is a data set all about characteristics of different cars"
 #' attr(x, "homepage") <- "https://github.com/cole-brokamp/dpkg"
 #' x
-as_dpkg <- function(x, name = deparse(substitute(x)), version = "0.0.0.9000",
-                    title = character(), homepage = character(), description = character()) {
+as_dpkg <- function(
+  x,
+  name = deparse(substitute(x)),
+  version = "0.0.0.9000",
+  title = character(),
+  homepage = character(),
+  description = character()
+) {
   invisible(check_label(name, "name", required = TRUE))
   invisible(check_label(version, "version", required = TRUE))
   if (!is.package_version(as.package_version(version))) {
@@ -32,11 +38,16 @@ as_dpkg <- function(x, name = deparse(substitute(x)), version = "0.0.0.9000",
   } else if (!identical(tolower(name), name)) {
     rlang::abort("name must be all lowercase")
   } else if (grepl("[^a-zA-Z0-9._-]", name)) {
-    rlang::abort("name must only contain alphanumeric characters, except for `-`, `_`, and `.`")
-  } else if (length(homepage) == 1 && !grepl("^((http|ftp)s?|sftp)://", homepage)) {
+    rlang::abort(
+      "name must only contain alphanumeric characters, except for `-`, `_`, and `.`"
+    )
+  } else if (
+    length(homepage) == 1 && !grepl("^((http|ftp)s?|sftp)://", homepage)
+  ) {
     rlang::abort("homepage must be a valid http, https, or sftp URL")
   }
-  tibble::new_tibble(tibble::validate_tibble(x),
+  tibble::new_tibble(
+    tibble::validate_tibble(x),
     class = "dpkg",
     name = check_label(name, "name", required = TRUE),
     version = check_label(version, "version", required = TRUE),
@@ -48,7 +59,9 @@ as_dpkg <- function(x, name = deparse(substitute(x)), version = "0.0.0.9000",
 
 #' @export
 print.dpkg <- function(x, ...) {
-  cli::cli_text("# [{cli::symbol$menu}] {attr(x, 'name')}-v{attr(x, 'version')}")
+  cli::cli_text(
+    "# [{cli::symbol$menu}] {attr(x, 'name')}-v{attr(x, 'version')}"
+  )
   if (length(attr(x, "title") > 0)) {
     cli::cli_text("# title: \"{attr(x, 'title')}\" ")
   }
@@ -70,7 +83,7 @@ print.dpkg <- function(x, ...) {
 #' attr(x, "description") <- "This is a data set all about characteristics of different cars"
 #' attr(x, "homepage") <- "https://github.com/cole-brokamp/dpkg"
 #' x
-#' 
+#'
 #' dpkg_meta(x)
 dpkg_meta <- function(x) {
   attributes(x)[c("name", "version", "title", "homepage", "description")]
@@ -78,7 +91,9 @@ dpkg_meta <- function(x) {
 
 check_label <- function(x, label_name, required = FALSE) {
   if (!is.character(x)) {
-    rlang::abort(glue::glue("`{label_name}` must be <character>, not <{class(x)}>"))
+    rlang::abort(glue::glue(
+      "`{label_name}` must be <character>, not <{class(x)}>"
+    ))
   } else if (required && length(x) != 1) {
     rlang::abort(glue::glue("`{label_name}` must be length 1"))
   } else if (length(x) > 1) {

--- a/R/read_write_dpkg.R
+++ b/R/read_write_dpkg.R
@@ -3,12 +3,22 @@
 read_dpkg_metadata <- function(x) {
   x_a <- arrow::open_dataset(x)
   if (length(x_a$metadata$r$attributes$class) == 0) {
-    rlang::abort("parquet file does not contain R specific metadata created when saving with the arrow package")
+    rlang::abort(
+      "parquet file does not contain R specific metadata created when saving with the arrow package"
+    )
   }
   if (!"dpkg" %in% x_a$metadata$r$attributes$class) {
     rlang::abort("R object in the parquet file must be class 'dpkg'")
   }
-  out <- x_a$metadata$r$attributes[c("name", "version", "title", "homepage", "description", "hash", "created")]
+  out <- x_a$metadata$r$attributes[c(
+    "name",
+    "version",
+    "title",
+    "homepage",
+    "description",
+    "hash",
+    "created"
+  )]
   out$created <- as.POSIXct(as.character(out$created))
   out$num_rows <- x_a$num_rows
   out$num_cols <- x_a$num_cols
@@ -58,12 +68,24 @@ read_dpkg <- function(x) {
 #' @returns path to the written file, invisibly
 #' @export
 write_dpkg <- function(x, dir) {
-  if (!inherits(x, "dpkg")) rlang::abort("x must be a `dpkg` object`")
-  out_path <- fs::path(dir, glue::glue("{attr(x, 'name')}-v{attr(x, 'version')}"), ext = "parquet")
-  attr(x, "hash") <- rlang::hash(x)
+  if (!inherits(x, "dpkg")) {
+    rlang::abort("x must be a `dpkg` object`")
+  }
+  out_path <- fs::path(
+    dir,
+    glue::glue("{attr(x, 'name')}-v{attr(x, 'version')}"),
+    ext = "parquet"
+  )
+  attr(x, "hash") <- digest::digest(
+    serialize(x, NULL, version = 2),
+    algo = "sha256"
+  )
   attr(x, "created") <- as.character(Sys.time())
   if ("sfc" %in% unlist(sapply(x, class))) {
-    rlang::check_installed("geoarrow", "to write geographic data in parquet files.")
+    rlang::check_installed(
+      "geoarrow",
+      "to write geographic data in parquet files."
+    )
     requireNamespace("geoarrow")
   }
   arrow::write_parquet(x, out_path)

--- a/R/stow.R
+++ b/R/stow.R
@@ -53,14 +53,17 @@ stow <- function(uri, overwrite = FALSE) {
       as.list() |>
       stats::setNames(c("owner", "repo", "dpkg"))
     out <-
-      stow_gh_release(uri_parts$owner,
+      stow_gh_release(
+        uri_parts$owner,
         repo = uri_parts$repo,
         dpkg = uri_parts$dpkg,
         overwrite = overwrite
       )
     return(out)
   }
-  rlang::abort("uri must begin with `https://`, `http://`, `ftp://`, or `gh://`")
+  rlang::abort(
+    "uri must begin with `https://`, `http://`, `ftp://`, or `gh://`"
+  )
 }
 
 #' download a file to the `stow` R user directory
@@ -119,7 +122,9 @@ stow_url <- function(url, overwrite = FALSE) {
 #'
 #' stow_remove(.delete_stow_dir_confirm = TRUE)
 stow_info <- function(filename = NULL) {
-  if (!stow_exists(filename)) rlang::abort("file or folder does not exist")
+  if (!stow_exists(filename)) {
+    rlang::abort("file or folder does not exist")
+  }
   if (is.null(filename)) {
     return(fs::dir_info(stow_path()))
   }
@@ -132,7 +137,9 @@ stow_info <- function(filename = NULL) {
 stow_path <- function(filename = NULL) {
   the_path <- fs::path(tools::R_user_dir("stow", "data"))
   fs::dir_create(the_path)
-  if (!is.null(filename)) the_path <- fs::path(the_path, filename)
+  if (!is.null(filename)) {
+    the_path <- fs::path(the_path, filename)
+  }
   return(as.character(the_path))
 }
 
@@ -158,10 +165,16 @@ stow_remove <- function(filename = NULL, .delete_stow_dir_confirm = FALSE) {
   if (is.null(filename)) {
     if (!.delete_stow_dir_confirm) {
       message(stow_path(), " has a total size of ", stow_size())
-      answer <- utils::askYesNo("Are you sure you want to delete the entire stow directory?")
+      answer <- utils::askYesNo(
+        "Are you sure you want to delete the entire stow directory?"
+      )
     }
-    if (.delete_stow_dir_confirm) answer <- TRUE
-    if (answer) fs::dir_delete(stow_path())
+    if (.delete_stow_dir_confirm) {
+      answer <- TRUE
+    }
+    if (answer) {
+      fs::dir_delete(stow_path())
+    }
     return(invisible(NULL))
   }
   fs::file_delete(stow_path(filename))

--- a/R/stow.R
+++ b/R/stow.R
@@ -25,7 +25,7 @@
 #' Sys.setenv(R_USER_DATA_DIR = tempfile("stow"))
 #' # get by using URL
 #' stow("https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds",
-#'      overwrite = TRUE
+#'   overwrite = TRUE
 #' ) |>
 #'   readRDS()
 #'
@@ -41,8 +41,7 @@
 #'   arrow::read_parquet()
 #'
 #' # use FTP protocol
-#' stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip")
-#'
+#' stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/ADDR/tl_2024_39061_addr.zip")
 stow <- function(uri, overwrite = FALSE) {
   if (grepl("^https?://", uri) || grepl("^ftp://", uri)) {
     out <- stow_url(url = uri, overwrite = overwrite)
@@ -61,7 +60,7 @@ stow <- function(uri, overwrite = FALSE) {
       )
     return(out)
   }
-  rlang::abort("uri must begin with `https://`, or `http://`, or `gh://`")
+  rlang::abort("uri must begin with `https://`, `http://`, `ftp://`, or `gh://`")
 }
 
 #' download a file to the `stow` R user directory
@@ -72,21 +71,18 @@ stow <- function(uri, overwrite = FALSE) {
 stow_url <- function(url, overwrite = FALSE) {
   if (!grepl("^https?://", url)) {
     if (!grepl("^ftp://", url)) {
-      rlang::abort("x must start with `http://` or `https://`")
+      rlang::abort("x must start with `http://`, `https://`, or `ftp://`")
     }
   }
   dest_path <- stow_path(fs::path_file(url))
-  if (fs::file_exists(dest_path) && !overwrite) {
-    return(dest_path)
+  if (!fs::file_exists(dest_path) || overwrite) {
+    tf <- tempfile()
+    on.exit(file.remove(tf))
+    utils::download.file(url, tf)
+    file.copy(tf, dest_path)
   }
-  tf <- tempfile()
-  on.exit(file.remove(tf))
-  ## httr2::request(url) |>
-  ##   httr2::req_options(verbose = TRUE) |>
-  ##   httr2::req_perform(path = dest_path)
-  download.file(url, tf, method = "libcurl")
-  file.copy(tf, dest_path)
-  return(dest_path)
+  out <- as.character(dest_path)
+  return(out)
 }
 
 #' get info about stowed files
@@ -137,7 +133,7 @@ stow_path <- function(filename = NULL) {
   the_path <- fs::path(tools::R_user_dir("stow", "data"))
   fs::dir_create(the_path)
   if (!is.null(filename)) the_path <- fs::path(the_path, filename)
-  return(the_path)
+  return(as.character(the_path))
 }
 
 #' test if a stowed file (or the stow directory) exists

--- a/R/stow.R
+++ b/R/stow.R
@@ -16,7 +16,7 @@
 #' has already been downloaded once, it will not be re-downloaded again
 #' (unless `overwrite = TRUE`).
 #' @param uri character string universal resource identifier; currently, must begin
-#' with `http://`, `https://`, or `gh://`
+#' with `http://`, `https://`, `ftp://`, or `gh://`
 #' @param overwrite logical; re-download the remote file even though
 #' a local file with the same name exists?
 #' @returns path to the stowed file or url to github release
@@ -38,9 +38,12 @@
 #' 
 #' stow("gh://cole-brokamp/dpkg/mtcars-v0.0.0.9000") |>
 #'   arrow::read_parquet()
+#'
+#' # use FTP protocol
+#' stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip")
 #' 
 stow <- function(uri, overwrite = FALSE) {
-  if (grepl("^https?://", uri)) {
+  if (grepl("^https?://", uri) || grepl("^ftp://", uri)) {
     out <- stow_url(url = uri, overwrite = overwrite)
     return(out)
   }
@@ -63,10 +66,14 @@ stow <- function(uri, overwrite = FALSE) {
 #' download a file to the `stow` R user directory
 #'
 #' @rdname stow
-#' @param url a URL string starting with `http://` or `https://`
+#' @param url a URL string starting with `http://`, `https://`, or `ftp://`
 #' @export
 stow_url <- function(url, overwrite = FALSE) {
-  if (!grepl("^https?://", url)) rlang::abort("x must start with `http://` or `https://`")
+  if (!grepl("^https?://", url)) {
+    if (!grepl("^ftp://", url)) {
+      rlang::abort("x must start with `http://` or `https://`")
+    }
+  }
   dest_path <- stow_path(fs::path_file(url))
   if (fs::file_exists(dest_path) && !overwrite) {
     return(dest_path)

--- a/R/stow.R
+++ b/R/stow.R
@@ -25,7 +25,8 @@
 #' Sys.setenv(R_USER_DATA_DIR = tempfile("stow"))
 #' # get by using URL
 #' stow("https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds",
-#'      overwrite = TRUE) |>
+#'      overwrite = TRUE
+#' ) |>
 #'   readRDS()
 #'
 #' # will be faster (even in later R sessions) next time
@@ -35,13 +36,13 @@
 #' # get a data package from a GitHub release
 #' stow("gh://cole-brokamp/dpkg/mtcars-v0.0.0.9000", overwrite = TRUE) |>
 #'   arrow::read_parquet()
-#' 
+#'
 #' stow("gh://cole-brokamp/dpkg/mtcars-v0.0.0.9000") |>
 #'   arrow::read_parquet()
 #'
 #' # use FTP protocol
 #' stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip")
-#' 
+#'
 stow <- function(uri, overwrite = FALSE) {
   if (grepl("^https?://", uri) || grepl("^ftp://", uri)) {
     out <- stow_url(url = uri, overwrite = overwrite)
@@ -78,7 +79,13 @@ stow_url <- function(url, overwrite = FALSE) {
   if (fs::file_exists(dest_path) && !overwrite) {
     return(dest_path)
   }
-  httr2::req_perform(httr2::request(url), path = dest_path)
+  tf <- tempfile()
+  on.exit(file.remove(tf))
+  ## httr2::request(url) |>
+  ##   httr2::req_options(verbose = TRUE) |>
+  ##   httr2::req_perform(path = dest_path)
+  download.file(url, tf, method = "libcurl")
+  file.copy(tf, dest_path)
   return(dest_path)
 }
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,12 +1,11 @@
 ## R CMD check results
 
-Submission of dpkg 0.6.1:
+Submission of dpkg 0.6.2:
 
-This is a bugfix release.
+This is a bugfix release for failing tests on CRAN <https://cran.r-project.org/web/checks/check_results_dpkg.html>
 
 0 errors | 0 warnings | 0 notes
 
-* R CMD checks passed with above results on:
-  - R v4.4.2 (macos, windows, and ubuntu)
-  - R v4.3.3 (ubuntu)
+- R CMD checks passed with above results on:
+  - R v4.4.3 (macos, windows, and ubuntu)
   - A development version of R (ubuntu and windows)

--- a/man/stow.Rd
+++ b/man/stow.Rd
@@ -23,9 +23,9 @@ stow_url(url, overwrite = FALSE)
 a local file with the same name exists?}
 
 \item{uri}{character string universal resource identifier; currently, must begin
-with \verb{http://}, \verb{https://}, or \verb{gh://}}
+with \verb{http://}, \verb{https://}, \verb{ftp://}, or \verb{gh://}}
 
-\item{url}{a URL string starting with \verb{http://} or \verb{https://}}
+\item{url}{a URL string starting with \verb{http://}, \verb{https://}, or \verb{ftp://}}
 }
 \value{
 path to the stowed file or url to github release
@@ -53,7 +53,8 @@ has already been downloaded once, it will not be re-downloaded again
 Sys.setenv(R_USER_DATA_DIR = tempfile("stow"))
 # get by using URL
 stow("https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds",
-     overwrite = TRUE) |>
+     overwrite = TRUE
+) |>
   readRDS()
 
 # will be faster (even in later R sessions) next time
@@ -66,5 +67,8 @@ stow("gh://cole-brokamp/dpkg/mtcars-v0.0.0.9000", overwrite = TRUE) |>
 
 stow("gh://cole-brokamp/dpkg/mtcars-v0.0.0.9000") |>
   arrow::read_parquet()
+
+# use FTP protocol
+stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip")
 
 }

--- a/man/stow.Rd
+++ b/man/stow.Rd
@@ -53,7 +53,7 @@ has already been downloaded once, it will not be re-downloaded again
 Sys.setenv(R_USER_DATA_DIR = tempfile("stow"))
 # get by using URL
 stow("https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds",
-     overwrite = TRUE
+  overwrite = TRUE
 ) |>
   readRDS()
 
@@ -69,6 +69,5 @@ stow("gh://cole-brokamp/dpkg/mtcars-v0.0.0.9000") |>
   arrow::read_parquet()
 
 # use FTP protocol
-stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip")
-
+stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/ADDR/tl_2024_39061_addr.zip")
 }

--- a/tests/testthat/test-check_name.R
+++ b/tests/testthat/test-check_name.R
@@ -1,5 +1,4 @@
 test_that("checking name property works", {
-
   as_dpkg(mtcars, name = "mtcars", version = "0.a1.2") |>
     expect_error("invalid version specification")
 
@@ -17,7 +16,7 @@ test_that("checking name property works", {
 
   as_dpkg(mtcars, name = "<foofy>") |>
     expect_error("name must only contain alphanumeric")
-  
+
   check_label("my_value", "the_name") |>
     expect_identical("my_value")
 
@@ -26,5 +25,4 @@ test_that("checking name property works", {
 
   check_label(c("a", "b"), "the_thing", required = TRUE) |>
     expect_error("`the_thing` must be length 1")
-
 })

--- a/tests/testthat/test-dpkg.R
+++ b/tests/testthat/test-dpkg.R
@@ -1,6 +1,9 @@
 test_that("as_dpkg() works", {
   x <- as_dpkg(mtcars, name = "mtcars", title = "Motor Trend Road Car Tests")
-  attr(x, "description")<- "This is a data set all about characteristics of different cars"
+  attr(
+    x,
+    "description"
+  ) <- "This is a data set all about characteristics of different cars"
   attr(x, "homepage") <- "https://github.com/cole-brokamp/dpkg"
 
   expect_s3_class(x, "dpkg")
@@ -8,8 +11,11 @@ test_that("as_dpkg() works", {
   dpkg_meta(x) |>
     expect_identical(
       list(
-        name = "mtcars", version = "0.0.0.9000", title = "Motor Trend Road Car Tests",
-        homepage = "https://github.com/cole-brokamp/dpkg", description = "This is a data set all about characteristics of different cars"
+        name = "mtcars",
+        version = "0.0.0.9000",
+        title = "Motor Trend Road Car Tests",
+        homepage = "https://github.com/cole-brokamp/dpkg",
+        description = "This is a data set all about characteristics of different cars"
       )
     )
 
@@ -19,8 +25,11 @@ test_that("as_dpkg() works", {
   x[1, ] |>
     dpkg_meta() |>
     expect_identical(list(
-      name = "mtcars", version = "0.0.0.9000", title = "Motor Trend Road Car Tests",
-      homepage = "https://github.com/cole-brokamp/dpkg", description = "This is a data set all about characteristics of different cars"
+      name = "mtcars",
+      version = "0.0.0.9000",
+      title = "Motor Trend Road Car Tests",
+      homepage = "https://github.com/cole-brokamp/dpkg",
+      description = "This is a data set all about characteristics of different cars"
     ))
 
   expect_snapshot(x[1, ])

--- a/tests/testthat/test-dpkg_tidy_methods.R
+++ b/tests/testthat/test-dpkg_tidy_methods.R
@@ -1,6 +1,9 @@
 test_that("extract dpkg", {
   x <- as_dpkg(mtcars, name = "mtcars", title = "Motor Trend Road Car Tests")
-  attr(x, "description") <- "This is a data set all about characteristics of different cars"
+  attr(
+    x,
+    "description"
+  ) <- "This is a data set all about characteristics of different cars"
   attr(x, "homepage") <- "https://github.com/cole-brokamp/dpkg"
   x[1] |>
     expect_s3_class("dpkg")
@@ -8,8 +11,11 @@ test_that("extract dpkg", {
 
 test_that("using dplyr verbs with dpkg objects do not error", {
   x <- as_dpkg(mtcars, name = "mtcars", title = "Motor Trend Road Car Tests")
-  attr(x, "description")<- "This is a data set all about characteristics of different cars"
-  attr(x, "homepage")<- "https://github.com/cole-brokamp/dpkg"
+  attr(
+    x,
+    "description"
+  ) <- "This is a data set all about characteristics of different cars"
+  attr(x, "homepage") <- "https://github.com/cole-brokamp/dpkg"
   dplyr::left_join(x, mtcars, by = "vs", relationship = "many-to-many") |>
     expect_no_error()
   dplyr::left_join(mtcars, x, by = "vs", relationship = "many-to-many") |>
@@ -31,5 +37,4 @@ test_that("using dplyr verbs with dpkg objects do not error", {
     expect_no_error()
   dplyr::slice(x, 1) |>
     expect_no_error()
-
 })

--- a/tests/testthat/test-read_dpkg.R
+++ b/tests/testthat/test-read_dpkg.R
@@ -1,6 +1,9 @@
 test_that("read_dpkg() and read_dpkg_metadata() works", {
   d <- as_dpkg(mtcars, version = "0.1.0", title = "Motor Trend Road Car Tests")
-  attr(d, "description") <- "This is a data set all about characteristics of different cars"
+  attr(
+    d,
+    "description"
+  ) <- "This is a data set all about characteristics of different cars"
   attr(d, "homepage") <- "https://github.com/cole-brokamp/dpkg"
 
   out <- write_dpkg(d, dir = tempdir())
@@ -22,16 +25,26 @@ test_that("read_dpkg() and read_dpkg_metadata() works", {
   the_md |>
     expect_identical(
       list(
-        name = "mtcars", version = "0.1.0",
+        name = "mtcars",
+        version = "0.1.0",
         title = "Motor Trend Road Car Tests",
         homepage = "https://github.com/cole-brokamp/dpkg",
         description = "This is a data set all about characteristics of different cars",
-        hash = "502c9e71f62f79debf7e769e071df0b4",
+        hash = "5affb6d56c4c97a6131dbe015f03b0b58cb653291706eeaaaac374f67a929c37",
         num_rows = 32L,
         num_cols = 11L,
         fields = c(
-          "mpg", "cyl", "disp", "hp", "drat",
-          "wt", "qsec", "vs", "am", "gear", "carb"
+          "mpg",
+          "cyl",
+          "disp",
+          "hp",
+          "drat",
+          "wt",
+          "qsec",
+          "vs",
+          "am",
+          "gear",
+          "carb"
         )
       )
     )

--- a/tests/testthat/test-stow.R
+++ b/tests/testthat/test-stow.R
@@ -10,6 +10,9 @@ test_that("stow_info() and friends work", {
   stow("https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds") |>
     expect_identical(stow_path("nei_2020.rds"))
 
+  stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip") |>
+    expect_identical(stow_path("tl_2024_us_county.zip"))
+
   stow_size("nei_2020.rds") |>
     expect_identical(structure(2883974, class = c("fs_bytes", "numeric")))
 

--- a/tests/testthat/test-stow.R
+++ b/tests/testthat/test-stow.R
@@ -1,7 +1,8 @@
 test_that("stow_info() and friends work", {
-  withr::local_envvar(R_USER_DATA_DIR = tempfile("stow"))
-
-  ## Sys.setenv(R_USER_DATA_DIR = tempfile("stow"))
+  withr::local_envvar(
+    R_USER_DATA_DIR = tempfile("stow"),
+    R_DEFAULT_INTERNET_TIMEOUT = 360
+  )
 
   expect_identical(fs::path_file(stow_path()), "stow")
 
@@ -10,8 +11,8 @@ test_that("stow_info() and friends work", {
   stow("https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds") |>
     expect_identical(stow_path("nei_2020.rds"))
 
-  stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip") |>
-    expect_identical(stow_path("tl_2024_us_county.zip"))
+  stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/ADDR/tl_2024_39061_addr.zip") |>
+    expect_identical(stow_path("tl_2024_39061_addr.zip"))
 
   stow_size("nei_2020.rds") |>
     expect_identical(structure(2883974, class = c("fs_bytes", "numeric")))

--- a/tests/testthat/test-stow.R
+++ b/tests/testthat/test-stow.R
@@ -8,10 +8,14 @@ test_that("stow_info() and friends work", {
 
   expect_true(grepl("Rtmp", stow_path(), fixed = TRUE))
 
-  stow("https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds") |>
+  stow(
+    "https://github.com/geomarker-io/appc/releases/download/v0.1.0/nei_2020.rds"
+  ) |>
     expect_identical(stow_path("nei_2020.rds"))
 
-  stow("ftp://ftp2.census.gov/geo/tiger/TIGER2024/ADDR/tl_2024_39061_addr.zip") |>
+  stow(
+    "ftp://ftp2.census.gov/geo/tiger/TIGER2024/ADDR/tl_2024_39061_addr.zip"
+  ) |>
     expect_identical(stow_path("tl_2024_39061_addr.zip"))
 
   stow_size("nei_2020.rds") |>
@@ -22,5 +26,4 @@ test_that("stow_info() and friends work", {
 
   stow_remove(.delete_stow_dir_confirm = TRUE)
   expect_identical(nrow(stow_info()), 0L)
-
 })

--- a/tests/testthat/test-write_dpkg.R
+++ b/tests/testthat/test-write_dpkg.R
@@ -1,6 +1,9 @@
 test_that("write_dpkg() works", {
   d <- as_dpkg(mtcars, version = "0.1.0", title = "Motor Trend Road Car Tests")
-  attr(d, "description") <- "This is a data set all about characteristics of different cars"
+  attr(
+    d,
+    "description"
+  ) <- "This is a data set all about characteristics of different cars"
   attr(d, "homepage") <- "https://github.com/cole-brokamp/dpkg"
 
   out <- write_dpkg(d, dir = tempdir())


### PR DESCRIPTION
rlang::hash can change based on the platform it is ran on and the R internals that my differ between operating systems and linked C/fortran libraries.

This lead to breaking tests on CRAN checks for newer operating systems.  Using digest package will prevent this in the future.